### PR TITLE
fix: set proper aws env var name

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -6,6 +6,6 @@ R2_SECRET_ACCESS_KEY="?"
 
 # Standard AWS Credentials if not set elsewhere
 # see: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-#AWS_ACCESS_KEY_ID="?"
-#AWS_SECRET_ACCESS_KEY="?"
-#AWS_DEFAULT_REGION="us-west-2"
+AWS_ACCESS_KEY_ID="?"
+AWS_SECRET_ACCESS_KEY="?"
+AWS_REGION="us-west-2"


### PR DESCRIPTION
Also took out `#` for commenting out AWS env variables in the template to be consistent with how the CF variables were templated out - but alternatively comment out the CF variables by default